### PR TITLE
Focus Corresponding Dropdown When SSML Tag is Highlighted in Textarea

### DIFF
--- a/src/components/ttsaas.js
+++ b/src/components/ttsaas.js
@@ -354,46 +354,35 @@ export default class TTSaaS extends BaseClass {
 
   getVoicesSelectOptions() {
     let voiceOptions = []
-    let ssmlVoiceOptionsDropdown = []
     let ssmlVoiceOptions = {}
     let lastLang = null
     this.state.voices.forEach((v, idx) => {
       if(v.sampleRateHz === 22050){
         if(lastLang != v.language){
-          voiceOptions.push(<optgroup key={'optgroup-'+idx} label={v.language}></optgroup>)
-          ssmlVoiceOptionsDropdown.push(<Dropdown.Header className="w-100" key={'optgroup-'+idx}>{v.language}</Dropdown.Header>);
+          voiceOptions.push(<Dropdown.Header className="w-100" key={'optgroup-'+idx}>{v.language}</Dropdown.Header>);
           lastLang = v.language
         }
-        voiceOptions.push(<option key={'option-'+idx} value={v.name}>{v.name}</option>)
-        ssmlVoiceOptionsDropdown.push(<Dropdown.Item className="w-100" key={'option-'+idx} eventKey={v.name}>{v.name}</Dropdown.Item>)
+        voiceOptions.push(<Dropdown.Item className="w-100" key={'option-'+idx} eventKey={v.name}>{v.name}</Dropdown.Item>)
         ssmlVoiceOptions[v.name] = {
           name: v.name
         }
       }
     })
-    return [voiceOptions, ssmlVoiceOptionsDropdown, ssmlVoiceOptions]
+    return [voiceOptions, ssmlVoiceOptions]
   }
 
-  onChangeVoice(evt) {
-    // Handle text input
-    const tgt = evt.target
-    switch(tgt.name){
-      case 'voice':
-        let voice = null
-        this.state.voices.forEach(v => {
-          if(v.sampleRateHz === 22050){
-            if(tgt.value === v.name){
-              voice = v
-              return
-            }
-          }
-        })
-        if(voice){
-          this.onUseVoice(voice)
+  onChangeVoice(voiceName) {
+    let voice = null
+    this.state.voices.forEach(v => {
+      if(v.sampleRateHz === 22050){
+        if(voiceName === v.name){
+          voice = v
+          return
         }
-        break
-      default:
-        break
+      }
+    })
+    if(voice){
+      this.onUseVoice(voice)
     }
   }
 
@@ -504,7 +493,7 @@ export default class TTSaaS extends BaseClass {
   }
 
   getSynthesizeHtml() {
-    let [voiceOptions, ssmlVoiceOptionsDropdown, ssmlVoiceOptions] = this.getVoicesSelectOptions();
+    let [voiceOptions, ssmlVoiceOptions] = this.getVoicesSelectOptions();
     const voiceTag = {
       ...VOICE_TAG_BASE,
       options: ssmlVoiceOptions
@@ -544,12 +533,14 @@ export default class TTSaaS extends BaseClass {
                   </Col>
                   <Col sm={6} md={4}>
                     <div className="d-flex">
-                        <Form.Group className="form-floating mb-2 mt-sm-2 mt-md-0 w-100">
-                          <Form.Control name="voice" as="select" value={this.state.voice.name} onChange={this.onChangeVoice.bind(this)}>
-                            { voiceOptions }
-                          </Form.Control>
-                          <Form.Label htmlFor="voice">Voice</Form.Label>
-                        </Form.Group>
+                        <Dropdown className="form-floating mb-2 mt-sm-2 mt-md-0 w-100" onSelect={(eventKey) => this.onChangeVoice(eventKey)}>
+                          <Dropdown.Toggle variant="secondary" className="w-100 d-flex justify-content-center align-items-center">
+                            {this.state.voice.name}
+                          </Dropdown.Toggle>
+                          <Dropdown.Menu className="w-100">
+                            {voiceOptions}
+                          </Dropdown.Menu>
+                        </Dropdown>
                         {!this.state.selectVoiceTagActive && 
                           <div className="mb-2 d-flex justify-content-center align-items-center flex-column" style={{marginLeft: ".5rem"}}>
                             <svg xmlns="http://www.w3.org/2000/svg" width="32" height="100%" fill="currentColor" className="bi bi-question-square-fill cursor-pointer text-secondary add-voice-btn" viewBox="0 0 16 16" onClick={() => this.setState({
@@ -569,7 +560,7 @@ export default class TTSaaS extends BaseClass {
                           {voiceTag.name}
                         </Dropdown.Toggle>
                         <Dropdown.Menu className="w-100">
-                          {ssmlVoiceOptionsDropdown}
+                          {voiceOptions}
                         </Dropdown.Menu>
                       </Dropdown>
                     }

--- a/src/components/ttsaas.js
+++ b/src/components/ttsaas.js
@@ -183,7 +183,6 @@ export default class TTSaaS extends BaseClass {
     }
     this.audioSink = null
     this.focusedDropdown = null
-    console.log('const')
   }
 
   componentDidMount(){
@@ -471,7 +470,6 @@ export default class TTSaaS extends BaseClass {
         return true;
       }
     })
-    console.log("selectedOption", selectedOption);
     return selectedOption;
   }
 

--- a/src/components/ttsaas.js
+++ b/src/components/ttsaas.js
@@ -20,7 +20,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlay } from '@fortawesome/free-solid-svg-icons'
 
 import { BaseClass, AuthForm, CLIENT_DATA, ROOT_URL, LANG_EMOJIS } from "./shared"
-import { DEFAULT_SSML_VALUE, NEEDS_INPUT, SSML_OPTIONS, VOICE_TAG_BASE } from "../utility/ssml-options"
+import { DROPDOWN_FOCUS_CLASS, NEEDS_INPUT, SSML_OPTIONS, VOICE_TAG_BASE } from "../utility/ssml-options"
 
 const ReactJson = loadable(() => import('react-json-view'))
 const Tabs = loadable(() => import('react-bootstrap/Tabs'))
@@ -175,7 +175,6 @@ export default class TTSaaS extends BaseClass {
         "name": "Evan", 
         "model": "xpremium-high" 
       },
-      defaultSSMLValue: DEFAULT_SSML_VALUE,
       selectVoiceTagActive: false,
       synthesizedAudioClips: [],
       processing: ProcessingState.IDLE,
@@ -473,33 +472,31 @@ export default class TTSaaS extends BaseClass {
     return selectedOption;
   }
 
+  blurFocusedDropdown(){
+    if(this.focusedDropdown){
+      this.refs[this.focusedDropdown].classList.remove(DROPDOWN_FOCUS_CLASS);
+      this.focusedDropdown = null;
+    }
+  }
+
   findSSMLTagFromText(text){
     const selectedOption = this.lookForSSMLOptionFromText(text);
     if(selectedOption !== undefined && selectedOption.name){
-      if(this.focusedDropdown && this.focusedDropdown !== selectedOption.name && this.refs[this.focusedDropdown].getAttribute("aria-expanded") != "false"){
-        this.refs[this.focusedDropdown].click();
-        this.focusedDropdown = null;
-      }
-      if(this.refs[selectedOption.name].getAttribute("aria-expanded") == "false"){
-        this.refs[selectedOption.name].click();
+      if(this.focusedDropdown !== selectedOption.name){
+        if(this.focusedDropdown) this.refs[this.focusedDropdown].classList.remove(DROPDOWN_FOCUS_CLASS);
+        this.refs[selectedOption.name].classList.add(DROPDOWN_FOCUS_CLASS);
         this.focusedDropdown = selectedOption.name;
       }
     }
     else{
-      if(this.focusedDropdown && this.refs[this.focusedDropdown].getAttribute("aria-expanded") != "false"){
-        this.refs[this.focusedDropdown].click();
-        this.focusedDropdown = null;
-      }
+      this.blurFocusedDropdown()
     }
   }
 
   compareSelectedTextToSSML(){
     const textToSynthesize = this.refs.textToSynthesize;
     if(textToSynthesize.selectionStart === textToSynthesize.selectionEnd) {
-      if(this.focusedDropdown && this.refs[this.focusedDropdown].getAttribute("aria-expanded") != "false"){
-        this.refs[this.focusedDropdown].click();
-        this.focusedDropdown = null;
-      }
+      this.blurFocusedDropdown()
       return;
     }
     let selectedText = this.state.textInput.substring(textToSynthesize.selectionStart, textToSynthesize.selectionEnd);
@@ -564,7 +561,10 @@ export default class TTSaaS extends BaseClass {
                         }
                     </div>
                     {this.state.selectVoiceTagActive && 
-                      <Dropdown className="form-floating mb-2" style={{marginLeft: "2rem", width: "calc(100% - 2rem)"}} onSelect={(eventKey) => this.addSSML(VOICE_NAME, eventKey, {voice: voiceTag})} onToggle={() => this.refs.textToSynthesize.focus()}>
+                      <Dropdown className="form-floating mb-2" style={{marginLeft: "2rem", width: "calc(100% - 2rem)"}} onSelect={(eventKey) => this.addSSML(VOICE_NAME, eventKey, {voice: voiceTag})} onToggle={() => {
+                        this.refs.textToSynthesize.focus();
+                        this.blurFocusedDropdown();
+                      }}>
                         <Dropdown.Toggle variant="light" className="w-100 d-flex justify-content-center align-items-center" ref={voiceTag.name}>
                           {voiceTag.name}
                         </Dropdown.Toggle>
@@ -575,7 +575,10 @@ export default class TTSaaS extends BaseClass {
                     }
                     {Object.entries(SSML_OPTIONS).map(([ssmlName, ssmlOptions], index) => {
                       return (
-                          <Dropdown className="form-floating mb-2 w-100" key={index} onToggle={() => this.refs.textToSynthesize.focus()}>
+                          <Dropdown className="form-floating mb-2 w-100" key={index} onToggle={() => {
+                              this.refs.textToSynthesize.focus();
+                              this.blurFocusedDropdown();
+                            }}>
                             <Dropdown.Toggle variant="light" className="w-100 d-flex justify-content-center align-items-center" ref={ssmlOptions.name}>
                               {ssmlOptions.name}
                             </Dropdown.Toggle>

--- a/src/components/ttsaas.js
+++ b/src/components/ttsaas.js
@@ -6,7 +6,7 @@
  * the LICENSE.md file in the root directory of this source tree.
  *
  */
-import React, { useState } from "react"
+import React, { useState, createRef } from "react"
 
 import loadable from '@loadable/component'
 
@@ -182,6 +182,8 @@ export default class TTSaaS extends BaseClass {
       voices: []
     }
     this.audioSink = null
+    this.focusedDropdown = null
+    console.log('const')
   }
 
   componentDidMount(){
@@ -476,15 +478,32 @@ export default class TTSaaS extends BaseClass {
   findSSMLTagFromText(text){
     const selectedOption = this.lookForSSMLOptionFromText(text);
     if(selectedOption !== undefined && selectedOption.name){
+      if(this.focusedDropdown && this.focusedDropdown !== selectedOption.name && this.refs[this.focusedDropdown].getAttribute("aria-expanded") != "false"){
+        this.refs[this.focusedDropdown].click();
+        this.focusedDropdown = null;
+      }
       if(this.refs[selectedOption.name].getAttribute("aria-expanded") == "false"){
         this.refs[selectedOption.name].click();
+        this.focusedDropdown = selectedOption.name;
+      }
+    }
+    else{
+      if(this.focusedDropdown && this.refs[this.focusedDropdown].getAttribute("aria-expanded") != "false"){
+        this.refs[this.focusedDropdown].click();
+        this.focusedDropdown = null;
       }
     }
   }
 
   compareSelectedTextToSSML(){
     const textToSynthesize = this.refs.textToSynthesize;
-    if(textToSynthesize.selectionStart === textToSynthesize.selectionEnd) return;
+    if(textToSynthesize.selectionStart === textToSynthesize.selectionEnd) {
+      if(this.focusedDropdown && this.refs[this.focusedDropdown].getAttribute("aria-expanded") != "false"){
+        this.refs[this.focusedDropdown].click();
+        this.focusedDropdown = null;
+      }
+      return;
+    }
     let selectedText = this.state.textInput.substring(textToSynthesize.selectionStart, textToSynthesize.selectionEnd);
     this.findSSMLTagFromText(selectedText);
   }
@@ -524,7 +543,7 @@ export default class TTSaaS extends BaseClass {
                     <Form.Group className="form-floating h-100">
                       <Form.Control className={(!this.state.textInput || this.state.textInput.length <= 0) ? "h-100" : "h-100 pt-2"} 
                         name="textInput" type="text" as="textarea" value={this.state.textInput} placeholder="Start typing here..." 
-                        onChange={this.onChangeTextInput.bind(this)} onKeyUp={this.compareSelectedTextToSSML.bind(this)} ref='textToSynthesize'/>
+                        onChange={this.onChangeTextInput.bind(this)} onKeyUp={this.compareSelectedTextToSSML.bind(this)} onMouseUp={this.compareSelectedTextToSSML.bind(this)} ref='textToSynthesize'/>
                       {(!this.state.textInput || this.state.textInput.length <= 0) && <Form.Label htmlFor="textInput">Text to Synthesize</Form.Label>}
                     </Form.Group>
                   </Col>

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -210,3 +210,10 @@ input:checked + .slider:after{
   max-height: 30vh;
   overflow-y: auto;
 }
+
+.dropdown-focus {
+  color: #000;
+  background-color: #f9fafb;
+  border-color: #f9fafb;
+  box-shadow: 0 0 0 0.25rem rgb(211 212 213 / 50%);
+}

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -201,7 +201,12 @@ input:checked + .slider:after{
   color: #5c636a !important;
 }
 
-/* .dropdown-toggle::after {
+.dropdown-toggle::after {
   margin-left: auto;
   display: inline-flex;
-} */
+}
+
+.dropdown-menu {
+  max-height: 30vh;
+  overflow-y: auto;
+}

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -200,3 +200,8 @@ input:checked + .slider:after{
 .add-voice-btn:hover {
   color: #5c636a !important;
 }
+
+/* .dropdown-toggle::after {
+  margin-left: auto;
+  display: inline-flex;
+} */

--- a/src/utility/ssml-options.js
+++ b/src/utility/ssml-options.js
@@ -220,3 +220,5 @@ export const VOICE_TAG_BASE = {
     attributes: ['name'],
     url: 'https://docs.mix.nuance.com/tts-grpc/v1/#voice',
 }
+
+export const DROPDOWN_FOCUS_CLASS = "dropdown-focus";

--- a/src/utility/ssml-options.js
+++ b/src/utility/ssml-options.js
@@ -4,6 +4,7 @@ export const DEFAULT_SSML_VALUE = "DEFAULT"
 const speakingStyle = {
     tag: 'style',
     name: 'Speaking Style',
+    defaultValue: 'e.g. neutral, lively, forceful, ...',
     url: 'https://docs.mix.nuance.com/tts-grpc/v1/#style',
     container: true,
     attributes: ['name'],
@@ -27,6 +28,7 @@ const pause = {
     tag: 'break',
     container: false,
     name: 'Pause',
+    defaultValue: 'e.g. weak, medium, strong, ...',
     url: 'https://docs.mix.nuance.com/tts-grpc/v1/#break',
     attributes: ['strength', 'time'],
     options: {
@@ -65,6 +67,7 @@ const timbre = {
     tag: 'prosody',
     container: true,
     name: 'Timbre',
+    defaultValue: 'e.g. young, medium, old, ...',
     url: 'https://docs.mix.nuance.com/tts-grpc/v1/#prosody-timbre',
     attributes: ['timbre'],
     options: {
@@ -109,6 +112,7 @@ const pitch = {
     tag: 'prosody',
     container: true,
     name: 'Pitch',
+    defaultValue: 'e.g. low, medium, high, ...',
     url: 'https://docs.mix.nuance.com/tts-grpc/v1/#prosody-pitch',
     attributes: ['pitch'],
     options: {
@@ -148,6 +152,7 @@ const pitch = {
 const speechRate = {
     tag: 'prosody',
     container: true,
+    defaultValue: 'e.g. slow, medium, fast, ...',
     name: 'Speech Rate',
     attributes: ['rate'],
     url: 'https://docs.mix.nuance.com/tts-grpc/v1/#prosody-rate',

--- a/src/utility/ssml-options.js
+++ b/src/utility/ssml-options.js
@@ -211,3 +211,12 @@ export const SSML_OPTIONS = {
     pitch,
     speechRate
 }
+
+export const VOICE_TAG_BASE = {
+    tag: 'voice',
+    container: true,
+    name: 'Voice Tag',
+    defaultValue: 'e.g. Evan, Chloe, ...',
+    attributes: ['name'],
+    url: 'https://docs.mix.nuance.com/tts-grpc/v1/#voice',
+}


### PR DESCRIPTION
- When a user highlights text in the "Text to Synthesize" textarea (using their mouse or keys):
  - A check is made to see if the highlighted text matches an ssml tag that we have support for in our tool
  - If it matches, we simulate "focus" on the corresponding dropdown for this ssml tag by applying a class that will outline the dropdown
  - While text that starts with a valid ssml tag is highlighted, the user can select a new value from the corresponding dropdown and it will replace the current value there
  - As soon as the selected area no longer matches a valid ssml tag, the "focus" is removed from the dropdown
- The `<select>` tags that were previously used have been converted to react-bootstrap dropdowns
- The colour of the main voice dropdown is different from the SSML tag dropdowns to make it easier to distinguish